### PR TITLE
Add a configuration option to silence error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,11 @@
 						"type": "string",
 						"default": "{appname}",
 						"description": "Custom string for the smallImageText section of the rich presence"
+					},
+					"discord.silent": {
+						"type": "boolean",
+						"default": false,
+						"description": "Decides if error messages are shown to the user"
 					}
 				}
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,12 +119,12 @@ function initRPC(clientID: string): void {
 
 	// Log in to the RPC Client, and check whether or not it errors.
 	rpc.login(clientID).catch(error => {
+		if (reconnectTimer) {
+			// Destroy and dispose of everything after a default of 20 reconnect attempts
+			if (reconnectCounter >= config.get('reconnectThreshold')) destroyRPC();
+			else return;
+		}
 		if(!config.get('silent')) {
-			if (reconnectTimer) {
-				// Destroy and dispose of everything after a default of 20 reconnect attempts
-				if (reconnectCounter >= config.get('reconnectThreshold')) destroyRPC();
-				else return;
-			}
 			if (error.message.includes('ENOENT')) window.showErrorMessage('No Discord Client detected!');
 			else window.showErrorMessage(`Couldn't connect to discord via rpc: ${error.message}`);
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,13 +119,15 @@ function initRPC(clientID: string): void {
 
 	// Log in to the RPC Client, and check whether or not it errors.
 	rpc.login(clientID).catch(error => {
-		if (reconnectTimer) {
-			// Destroy and dispose of everything after a default of 20 reconnect attempts
-			if (reconnectCounter >= config.get('reconnectThreshold')) destroyRPC();
-			else return;
+		if(!config.get('silent')) {
+			if (reconnectTimer) {
+				// Destroy and dispose of everything after a default of 20 reconnect attempts
+				if (reconnectCounter >= config.get('reconnectThreshold')) destroyRPC();
+				else return;
+			}
+			if (error.message.includes('ENOENT')) window.showErrorMessage('No Discord Client detected!');
+			else window.showErrorMessage(`Couldn't connect to discord via rpc: ${error.message}`);
 		}
-		if (error.message.includes('ENOENT')) window.showErrorMessage('No Discord Client detected!');
-		else window.showErrorMessage(`Couldn't connect to discord via rpc: ${error.message}`);
 	});
 }
 


### PR DESCRIPTION
There are times where I use vscode without having discord started, so this configuration option allows me to hide the error which shows when I have no client started:

![image](https://user-images.githubusercontent.com/6440374/33723256-30d0c0e4-db3a-11e7-8706-bdfe02e701b6.png)

(also shouldn't this be "No Discord Client detected!"?)