### PR TITLE
Fix boolean expression to determine start timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
 						"type": "boolean",
 						"default": false,
 						"description": "Decides if error messages are shown to the user"
+					},
+					"discord.workspaceElapsedTime": {
+						"type": "boolean",
+						"default": false,
+						"description": "Decides whether to display elapsed time for a workspace or a single file"
 					}
 				}
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,12 +93,18 @@ function initRPC(clientID: string): void {
 		setActivity();
 		// Set the activity once on ready
 		setTimeout(() => rpc.setActivity(activity), 500);
-		eventHandlers.add(workspace.onDidChangeTextDocument(() => setActivity()))
-			.add(workspace.onDidOpenTextDocument(() => setActivity()))
-			.add(workspace.onDidCloseTextDocument(() => setActivity()))
-			.add(debug.onDidChangeActiveDebugSession(() => setActivity()))
+		eventHandlers.add(debug.onDidChangeActiveDebugSession(() => setActivity()))
 			.add(debug.onDidStartDebugSession(() => setActivity()))
 			.add(debug.onDidTerminateDebugSession(() => setActivity()));
+		if (config.get('workspaceElapsedTime')) {
+			eventHandlers.add(workspace.onDidChangeTextDocument(() => setActivity(true)))
+				.add(workspace.onDidOpenTextDocument(() => setActivity(true)))
+				.add(workspace.onDidCloseTextDocument(() => setActivity(true)));
+		} else {
+			eventHandlers.add(workspace.onDidChangeTextDocument(() => setActivity()))
+				.add(workspace.onDidOpenTextDocument(() => setActivity()))
+				.add(workspace.onDidCloseTextDocument(() => setActivity()));
+		}
 		// Make sure to listen to the close event and dispose and destroy everything accordingly.
 		rpc.transport.once('close', () => {
 			if (!config.get('enabled')) return;
@@ -151,7 +157,7 @@ function destroyRPC(): void {
 }
 
 // This function updates the activity (The Client's Rich Presence status).
-function setActivity(): void {
+function setActivity(workspaceElapsedTime: boolean = false): void {
 	// Do not continue if RPC isn't initalized.
 	if (!rpc) return;
 	if (window.activeTextEditor && window.activeTextEditor.document.fileName === lastKnownFileName) return;
@@ -168,11 +174,14 @@ function setActivity(): void {
 		})]
 		: 'vscode-big';
 
+	// Get the previous activity start timestamp (if available) to preserve workspace elapsed time
+	let previousTimestamp = null;
+	if (activity) previousTimestamp = activity['startTimestamp'];
 	// Create a JSON Object with the user's activity information.
 	activity = {
 		details: generateDetails('detailsDebugging', 'detailsEditing', 'detailsIdle'),
 		state: generateDetails('lowerDetailsDebugging', 'lowerDetailsEditing', 'lowerDetailsIdle'),
-		startTimestamp: new Date().getTime() / 1000,
+		startTimestamp: !previousTimestamp && !workspaceElapsedTime ? new Date().getTime() / 1000 : previousTimestamp,
 		largeImageKey: largeImageKey
 			? largeImageKey.image
 				|| largeImageKey

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,18 +93,13 @@ function initRPC(clientID: string): void {
 		setActivity();
 		// Set the activity once on ready
 		setTimeout(() => rpc.setActivity(activity), 500);
-		eventHandlers.add(debug.onDidChangeActiveDebugSession(() => setActivity()))
+		const workspaceElapsedTime = Boolean(config.get('workspaceElapsedTime'));
+		eventHandlers.add(workspace.onDidChangeTextDocument(() => setActivity(workspaceElapsedTime)))
+			.add(workspace.onDidOpenTextDocument(() => setActivity(workspaceElapsedTime)))
+			.add(workspace.onDidCloseTextDocument(() => setActivity(workspaceElapsedTime)))
+			.add(debug.onDidChangeActiveDebugSession(() => setActivity()))
 			.add(debug.onDidStartDebugSession(() => setActivity()))
 			.add(debug.onDidTerminateDebugSession(() => setActivity()));
-		if (config.get('workspaceElapsedTime')) {
-			eventHandlers.add(workspace.onDidChangeTextDocument(() => setActivity(true)))
-				.add(workspace.onDidOpenTextDocument(() => setActivity(true)))
-				.add(workspace.onDidCloseTextDocument(() => setActivity(true)));
-		} else {
-			eventHandlers.add(workspace.onDidChangeTextDocument(() => setActivity()))
-				.add(workspace.onDidOpenTextDocument(() => setActivity()))
-				.add(workspace.onDidCloseTextDocument(() => setActivity()));
-		}
 		// Make sure to listen to the close event and dispose and destroy everything accordingly.
 		rpc.transport.once('close', () => {
 			if (!config.get('enabled')) return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,7 +174,7 @@ function setActivity(workspaceElapsedTime: boolean = false): void {
 	activity = {
 		details: generateDetails('detailsDebugging', 'detailsEditing', 'detailsIdle'),
 		state: generateDetails('lowerDetailsDebugging', 'lowerDetailsEditing', 'lowerDetailsIdle'),
-		startTimestamp: !previousTimestamp && !workspaceElapsedTime ? new Date().getTime() / 1000 : previousTimestamp,
+		startTimestamp: previousTimestamp && workspaceElapsedTime ? previousTimestamp : new Date().getTime() / 1000,
 		largeImageKey: largeImageKey
 			? largeImageKey.image
 				|| largeImageKey


### PR DESCRIPTION
Messed up the expression to determine the start timestamp in the last PR, which was causing the extension to always display workspace elapsed time regardless of setting. It should be fixed with this PR.

The expression now goes like this:
```
If a previous timestamp exists, and the user wants workspace elapsed time,
  set startTimestamp to previousTimestamp.
Else (no previous timestamp or the user wants file elapsed time),
  generate a new timestamp for startTimestamp.
```