### PR TITLE
misc: Capitalize Discord and RPC in an error message

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,7 +122,7 @@ function initRPC(clientID: string): void {
 		}
 		if (!config.get('silent')) {
 			if (error.message.includes('ENOENT')) window.showErrorMessage('No Discord Client detected!');
-			else window.showErrorMessage(`Couldn't connect to discord via rpc: ${error.message}`);
+			else window.showErrorMessage(`Couldn't connect to Discord via RPC: ${error.message}`);
 		}
 	});
 }


### PR DESCRIPTION
Because well... In my opinion it looked bad.