### PR TITLE
fix: Desync issues with config updates

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,7 +112,6 @@ function initRPC(clientID: string, loud?: boolean): void {
 		setActivity();
 		// Set the activity once on ready
 		setTimeout(() => rpc.setActivity(activity), 500);
-		const workspaceElapsedTime = Boolean(config.get('workspaceElapsedTime'));
 		// Make sure to listen to the close event and dispose and destroy everything accordingly.
 		rpc.transport.once('close', async () => {
 			if (!config.get('enabled')) return;
@@ -127,7 +126,7 @@ function initRPC(clientID: string, loud?: boolean): void {
 
 		// Update the user's activity to the `activity` variable.
 		activityTimer = setInterval(() => {
-			setActivity(workspaceElapsedTime);
+			setActivity(Boolean(config.get('workspaceElapsedTime')));
 			rpc.setActivity(activity);
 		}, 15000);
 	});
@@ -218,6 +217,9 @@ async function destroyRPC(): Promise<void> {
 function setActivity(workspaceElapsedTime: boolean = false): void {
 	// Do not continue if RPC isn't initalized.
 	if (!rpc) return;
+	// Update the config before updating the activity
+	config = workspace.getConfiguration('discord');
+
 	if (window.activeTextEditor && window.activeTextEditor.document.fileName === lastKnownFileName) return;
 	lastKnownFileName = window.activeTextEditor ? window.activeTextEditor.document.fileName : null;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,6 +126,8 @@ function initRPC(clientID: string, loud?: boolean): void {
 
 		// Update the user's activity to the `activity` variable.
 		activityTimer = setInterval(() => {
+			// Update the config before updating the activity
+			config = workspace.getConfiguration('discord');
 			setActivity(Boolean(config.get('workspaceElapsedTime')));
 			rpc.setActivity(activity);
 		}, 15000);
@@ -217,8 +219,6 @@ async function destroyRPC(): Promise<void> {
 function setActivity(workspaceElapsedTime: boolean = false): void {
 	// Do not continue if RPC isn't initalized.
 	if (!rpc) return;
-	// Update the config before updating the activity
-	config = workspace.getConfiguration('discord');
 
 	if (window.activeTextEditor && window.activeTextEditor.document.fileName === lastKnownFileName) return;
 	lastKnownFileName = window.activeTextEditor ? window.activeTextEditor.document.fileName : null;


### PR DESCRIPTION
This PR fixes the desync issues that happen when you update the config, but not reload.

Before it would just ignore the new settings till you reloaded. Now, it gets updated before setting the activity.

Fixes #27 