### PR TITLE
feature: Allow the language key to be added to the largeImage text

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,8 +91,8 @@
 					},
 					"discord.largeImage": {
 						"type": "string",
-						"default": "",
-						"description": "Custom string for the largeImageText section of the rich presence"
+						"default": "Editing a {LANG} file",
+						"description": "Custom string for the largeImageText section of the rich presence.\n\t- '{lang}' will be replaced with the lowercased language ID\n\t- '{LANG}' will be replaced with the uppercased language ID"
 					},
 					"discord.largeImageIdle": {
 						"type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -245,7 +245,7 @@ function setActivity(workspaceElapsedTime: boolean = false): void {
 					|| largeImageKey
 			: 'txt',
 		largeImageText: window.activeTextEditor
-			? config.get('largeImage')
+			? config.get('largeImage').replace('{lang}', largeImageKey.image || largeImageKey).replace('{LANG}', largeImageKey.image.toUpperCase() || largeImageKey.toUpperCase())
 				|| window.activeTextEditor.document.languageId.padEnd(2, '\u200b')
 			: config.get('largeImageIdle'),
 		smallImageKey: debug.activeDebugSession


### PR DESCRIPTION
This PR allows people to set custom things like `Editing a JS file` in the large image text, should they choose so.

Naming of the parameters can be changed if needed. But as they stand right now, I feel like they match what they do.

This closes #26 