### PR TITLE
feat: Allow people to set the state or description section to be empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,12 +63,12 @@
 					"discord.detailsEditing": {
 						"type": "string",
 						"default": "Editing {filename}",
-						"description": "Custom string for the details section of the rich presence"
+						"description": "Custom string for the details section of the rich presence\nIf this is set to '{null}', it will be replaced with an empty space"
 					},
 					"discord.detailsDebugging": {
 						"type": "string",
 						"default": "Editing {filename}",
-						"description": "Custom string for the details section of the rich presence when debugging"
+						"description": "Custom string for the details section of the rich presence when debugging\nIf this is set to '{null}', it will be replaced with an empty space"
 					},
 					"discord.detailsIdle": {
 						"type": "string",
@@ -78,12 +78,12 @@
 					"discord.lowerDetailsEditing": {
 						"type": "string",
 						"default": "Workspace: {workspace}",
-						"description": "Custom string for the state section of the rich presence"
+						"description": "Custom string for the state section of the rich presence\nIf this is set to '{null}', it will be replaced with an empty space"
 					},
 					"discord.lowerDetailsDebugging": {
 						"type": "string",
 						"default": "Debugging: {workspace}",
-						"description": "Custom string for the state section of the rich presence when debugging"
+						"description": "Custom string for the state section of the rich presence when debugging\nIf this is set to '{null}', it will be replaced with an empty space"
 					},
 					"discord.lowerDetailsIdle": {
 						"type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -269,17 +269,20 @@ function generateDetails(debugging, editing, idling): string {
 		: false;
 	const workspaceFolder: WorkspaceFolder = checkState ? workspace.getWorkspaceFolder(window.activeTextEditor.document.uri) : null;
 
+	const emptyDebugState: boolean = config.get(debugging) === '{null}';
+	const emptyEditingState: boolean = config.get(editing) === '{null}';
+
 	return window.activeTextEditor
 		? debug.activeDebugSession
-		? config.get(debugging)
-			.replace('{filename}', fileName)
-			.replace('{workspace}', checkState
-				? workspaceFolder.name
-				: config.get('lowerDetailsNotFound'))
-		: config.get(editing)
-			.replace('{filename}', fileName)
-			.replace('{workspace}', checkState
-				? workspaceFolder.name
-				: config.get('lowerDetailsNotFound'))
+			? emptyDebugState
+			? '\u200b\u200b'
+			: config.get(debugging)
+				.replace('{filename}', fileName)
+				.replace('{workspace}', checkState ? workspaceFolder.name : config.get('lowerDetailsNotFound'))
+		: emptyEditingState
+			? '\u200b\u200b'
+			: config.get(editing)
+				.replace('{filename}', fileName)
+				.replace('{workspace}', checkState ? workspaceFolder.name : config.get('lowerDetailsNotFound'))
 		: config.get(idling);
 }


### PR DESCRIPTION
Closes #31 

This PR allows people to have an empty state or description to be empty (it actually is a double 0-width space, it's the only way to do this).

So, if a user sets their `lowerDetailsEditing` to `{null}`, it will show an empty space. It's a limitation that we cannot overcome