### PR TITLE
fix: Don't show a timer on idle

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -239,7 +239,7 @@ function setActivity(workspaceElapsedTime: boolean = false): void {
 	activity = {
 		details: generateDetails('detailsDebugging', 'detailsEditing', 'detailsIdle'),
 		state: generateDetails('lowerDetailsDebugging', 'lowerDetailsEditing', 'lowerDetailsIdle'),
-		startTimestamp: previousTimestamp && workspaceElapsedTime ? previousTimestamp : new Date().getTime() / 1000,
+		startTimestamp: window.activeTextEditor && previousTimestamp && workspaceElapsedTime ? previousTimestamp : window.activeTextEditor ? new Date().getTime() / 1000 : null,
 		largeImageKey: largeImageKey
 			? largeImageKey.image
 					|| largeImageKey


### PR DESCRIPTION
Not needed anyways, and buggy to say the least.

Closes #51 