### PR TITLE
Adds DreamMaker support

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -21,6 +21,7 @@
 		"scss",
 		"d",
 		"dart",
+		"dm",
 		"manifest",
 		"delphi",
 		"docker",
@@ -271,6 +272,15 @@
 		},
 		".dart": {
 			"image": "dart"
+		},
+		".dm": {
+			"image": "dm"
+		},
+		".dme": {
+			"image": "dm"
+		},
+		".dmm": {
+			"image": "dm"
 		},
 		"/\\.(h|geo|topo)$/i": {
 			"image": "manifest"


### PR DESCRIPTION
DreamMaker is a language for the [BYOND game engine](https://secure.byond.com/).

Suggested image:

![](https://avatars0.githubusercontent.com/u/4378955?s=200&v=4)