### PR TITLE
add support for .sp files (SourcePawn)

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -680,6 +680,9 @@
 		".p": {
 			"image": "pawn"
 		},
+		".sp": {
+			"image": "pawn"
+		},
 		".py": {
 			"image": "python"
 		},


### PR DESCRIPTION
.sp files are used for [SourcePawn](https://wiki.alliedmods.net/Introduction_to_SourcePawn_1.7) development which, as the name suggests, is part of the Pawn language