### PR TITLE
Add reasonml support

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -62,6 +62,7 @@
 		"powershell",
 		"python",
 		"r",
+		"reasonml",
 		"ruby",
 		"rust",
 		"scala",
@@ -988,6 +989,9 @@
 		},
 		".nix": {
 			"image": "nix"
+		},
+		".re": {
+			"image": "reasonml"
 		}
 	}
 }


### PR DESCRIPTION
Add support for reasonml files in rich presence, with logo as below

![reasonlogo](https://user-images.githubusercontent.com/365376/47807607-84aad600-dd0a-11e8-86f6-e7e9fb7a349b.png)
