### PR TITLE
fix: Loads of bugs n quirks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "discord-vscode",
 	"displayName": "Discord Presence",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"description": "Update your discord status with the newly added rich presence.",
 	"private": true,
 	"author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "discord-vscode",
 	"displayName": "Discord Presence",
-	"version": "3.0.3",
+	"version": "3.0.2",
 	"description": "Update your discord status with the newly added rich presence.",
 	"private": true,
 	"author": {

--- a/src/client/RPCClient.ts
+++ b/src/client/RPCClient.ts
@@ -12,7 +12,7 @@ let activityTimer: NodeJS.Timer;
 
 export default class RPCClient implements Disposable {
 	public statusBarIcon: StatusBarItem;
-	public _config = workspace.getConfiguration('discord');
+	public config = workspace.getConfiguration('discord');
 
 	private _rpc: any;
 
@@ -42,7 +42,7 @@ export default class RPCClient implements Disposable {
 		Logger.log('Logging into RPC.');
 		this._rpc.once('ready', () => {
 			Logger.log('Successfully connected to Discord.');
-			if (!this._config.get<boolean>('silent')) window.showInformationMessage('Successfully connected to Discord RPC');
+			if (!this.config.get<boolean>('silent')) window.showInformationMessage('Successfully connected to Discord RPC');
 
 			this.statusBarIcon.hide();
 
@@ -53,14 +53,14 @@ export default class RPCClient implements Disposable {
 			this.setActivity();
 
 			this._rpc.transport.once('close', async () => {
-				if (!this._config.get<boolean>('enabled')) return;
+				if (!this.config.get<boolean>('enabled')) return;
 				await this.dispose();
 				this.statusBarIcon.show();
 			});
 
 			activityTimer = setInterval(() => {
-				this._config = workspace.getConfiguration('discord');
-				this.setActivity(this._config.get<boolean>('workspaceElapsedTime'));
+				this.config = workspace.getConfiguration('discord');
+				this.setActivity(this.config.get<boolean>('workspaceElapsedTime'));
 			}, 10000);
 		});
 		await this._rpc.login({ clientId: this._clientId });

--- a/src/client/RPCClient.ts
+++ b/src/client/RPCClient.ts
@@ -3,7 +3,7 @@ import {
 	Disposable,
 	StatusBarItem,
 	window,
-	workspace,
+	workspace
 } from 'vscode';
 import Activity from '../structures/Activity';
 import Logger from '../structures/Logger';
@@ -11,32 +11,32 @@ import Logger from '../structures/Logger';
 let activityTimer: NodeJS.Timer;
 
 export default class RPCClient implements Disposable {
-	statusBarIcon: StatusBarItem;
-	_config = workspace.getConfiguration('discord');
+	public statusBarIcon: StatusBarItem;
+	public _config = workspace.getConfiguration('discord');
 
 	private _rpc: any;
 
 	private _activity = new Activity();
 
-	private _clientID: string;
+	private _clientId: string;
 
-	constructor(clientID: string, statusBarIcon: StatusBarItem) {
-		this._clientID = clientID;
+	public constructor(clientId: string, statusBarIcon: StatusBarItem) {
+		this._clientId = clientId;
 		this.statusBarIcon = statusBarIcon;
 	}
 
-	get client() {
+	public get client() {
 		return this._rpc;
 	}
 
-	setActivity(workspaceElapsedTime: boolean = false) {
+	public setActivity(workspaceElapsedTime: boolean = false) {
 		if (!this._rpc) return;
 		const activity = this._activity.generate(workspaceElapsedTime);
 		Logger.log('Sending activity to Discord.');
 		this._rpc.setActivity(activity);
 	}
 
-	async login() {
+	public async login() {
 		if (this._rpc) return;
 		this._rpc = new Client({ transport: 'ipc' });
 		Logger.log('Logging into RPC.');
@@ -63,10 +63,10 @@ export default class RPCClient implements Disposable {
 				this.setActivity(this._config.get<boolean>('workspaceElapsedTime'));
 			}, 10000);
 		});
-		await this._rpc.login({ clientId: this._clientID });
+		await this._rpc.login({ clientId: this._clientId });
 	}
 
-	async dispose() {
+	public async dispose() {
 		this._activity.dispose();
 		if (this._rpc) {
 			await this._rpc.destroy();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,5 +4,5 @@ export const VSLS_EXTENSION_ID = 'ms-vsliveshare.vsliveshare';
 export const LIVE_SHARE_COMMANDS = {
 	START: 'liveshare.start',
 	END: 'liveshare.end',
-	JOIN: 'liveshare.join',
+	JOIN: 'liveshare.join'
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,5 +4,5 @@ export const VSLS_EXTENSION_ID = 'ms-vsliveshare.vsliveshare';
 export const LIVE_SHARE_COMMANDS = {
 	START: 'liveshare.start',
 	END: 'liveshare.end',
-	JOIN: 'liveshare.join'
-}
+	JOIN: 'liveshare.join',
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ export async function activate(context: ExtensionContext) {
 
 	const disabler = commands.registerCommand('discord.disable', async () => {
 		await config.update('enabled', false);
-		rpc._config = workspace.getConfiguration('discord');
+		rpc.config = workspace.getConfiguration('discord');
 		await rpc.dispose();
 		window.showInformationMessage('Disabled Discord Rich Presence for this workspace.');
 	});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,50 +1,26 @@
-import RPCClient from './client/RPCClient';
-import Logger from './structures/Logger';
 import {
 	commands,
 	ExtensionContext,
-	StatusBarItem,
 	StatusBarAlignment,
+	StatusBarItem,
 	window,
-	workspace
+	workspace,
 } from 'vscode';
-import { setInterval, clearInterval } from 'timers';
+import RPCClient from './client/RPCClient';
+import Logger from './structures/Logger';
 
-let activityTimer: NodeJS.Timer;
-let statusBarIcon: StatusBarItem;
+const statusBarIcon: StatusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);
+statusBarIcon.text = '$(pulse) Connecting...';
+statusBarIcon.command = 'discord.reconnect';
 
 const config = workspace.getConfiguration('discord');
-const rpc = new RPCClient(config.get<string>('clientID')!);
+const rpc = new RPCClient(config.get<string>('clientID')!, statusBarIcon);
 
 export async function activate(context: ExtensionContext) {
 	Logger.log('Discord Presence activated!');
-	
-	rpc.client.once('ready', () => {
-		Logger.log('Successfully connected to Discord.');
-		if (!config.get<boolean>('silent')) window.showInformationMessage('Successfully reconnected to Discord RPC');
 
-		if (statusBarIcon) statusBarIcon.dispose();
-		if (activityTimer) clearInterval(activityTimer);
-		rpc.setActivity();
-
-		rpc.client.transport.once('close', async () => {
-			if (!config.get<boolean>('enabled')) return;
-			await rpc.dispose();
-			await rpc.login();
-			if (!statusBarIcon) {
-				statusBarIcon = window.createStatusBarItem(StatusBarAlignment.Left);
-				statusBarIcon.text = '$(plug) Reconnect to Discord';
-				statusBarIcon.command = 'discord.reconnect';
-				statusBarIcon.show();
-			}
-		});
-
-		activityTimer = setInterval(() => {
-			rpc.setActivity(config.get<boolean>('workspaceElapsedTime'));
-		}, 10000);
-	})
-	
 	if (config.get<boolean>('enabled')) {
+		statusBarIcon.show();
 		try {
 			await rpc.login();
 		} catch (error) {
@@ -53,24 +29,25 @@ export async function activate(context: ExtensionContext) {
 				if (error.message.includes('ENOENT')) window.showErrorMessage('No Discord Client detected!');
 				else window.showErrorMessage(`Couldn't connect to Discord via RPC: ${error.toString()}`);
 			}
-			if (!statusBarIcon) {
-				statusBarIcon = window.createStatusBarItem(StatusBarAlignment.Left);
-				statusBarIcon.text = '$(plug) Reconnect to Discord';
-				statusBarIcon.command = 'discord.reconnect';
-				statusBarIcon.show();
-			}
+			rpc.statusBarIcon.text = '$(pulse) Reconnect';
+			rpc.statusBarIcon.command = 'discord.reconnect';
+			rpc.statusBarIcon.show();
 		}
 	}
 
 	const enabler = commands.registerCommand('discord.enable', async () => {
 		await rpc.dispose();
 		await config.update('enabled', true);
+		rpc._config = workspace.getConfiguration('discord');
+		rpc.statusBarIcon.text = '$(pulse) Connecting...';
+		rpc.statusBarIcon.show();
 		await rpc.login();
 		window.showInformationMessage('Enabled Discord Rich Presence for this workspace.');
 	});
 
 	const disabler = commands.registerCommand('discord.disable', async () => {
 		await config.update('enabled', false);
+		rpc._config = workspace.getConfiguration('discord');
 		await rpc.dispose();
 		window.showInformationMessage('Disabled Discord Rich Presence for this workspace.');
 	});
@@ -79,15 +56,15 @@ export async function activate(context: ExtensionContext) {
 		await rpc.dispose();
 		await rpc.login();
 		if (!config.get('silent')) window.showInformationMessage('Reconnecting to Discord RPC...');
-		if (statusBarIcon) statusBarIcon.text = '$(pulse) reconnecting...';
+		rpc.statusBarIcon.text = '$(pulse) Reconnecting...';
+		rpc.statusBarIcon.command = undefined;
 	});
 
 	context.subscriptions.push(enabler, disabler, reconnecter);
 }
 
 export async function deactivate() {
-	clearInterval(activityTimer);
 	await rpc.dispose();
 }
 
-process.on('unhandledRejection', err => Logger.log(err));
+process.on('unhandledRejection', (err) => Logger.log(err));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import {
 	StatusBarAlignment,
 	StatusBarItem,
 	window,
-	workspace,
+	workspace
 } from 'vscode';
 import RPCClient from './client/RPCClient';
 import Logger from './structures/Logger';
@@ -67,4 +67,4 @@ export async function deactivate() {
 	await rpc.dispose();
 }
 
-process.on('unhandledRejection', (err) => Logger.log(err));
+process.on('unhandledRejection', err => Logger.log(err));

--- a/src/structures/Activity.ts
+++ b/src/structures/Activity.ts
@@ -1,17 +1,20 @@
+import { statSync } from 'fs';
+import { basename, parse, sep } from 'path';
 import {
 	debug,
 	Disposable,
 	env,
 	window,
-	workspace
+	workspace,
 } from 'vscode';
-import { basename, sep, parse } from 'path';
-import { statSync } from 'fs';
 const lang = require('../data/languages.json');
 const knownExtentions: { [key: string]: { image: string } } = lang.knownExtentions;
 const knownLanguages: string[] = lang.knownLanguages;
 
-interface Activity {
+const empty = '\u200b\u200b';
+const sizes = [' bytes', 'kb', 'mb', 'gb', 'tb'];
+
+interface IActivity {
 	details?: string;
 	state?: string;
 	startTimestamp?: number | null;
@@ -22,44 +25,44 @@ interface Activity {
 	instance?: boolean;
 }
 
-interface FileDetail {
+interface IFileDetail {
 	size?: string;
 	totalLines?: string;
 	currentLine?: string;
 	currentColumn?: string;
 }
 
-export default class Acivity implements Disposable {
-	private _state: Activity | null = null;
+export default class Activity implements Disposable {
+
+	get state() {
+		return this._state;
+	}
+	private _state: IActivity | null = null;
 
 	private _config = workspace.getConfiguration('discord');
 
 	private _lastKnownFile: string = '';
 
-	public get state() {
-		return this._state;
-	}
-
-	public generate(workspaceElapsedTime: boolean = false) {
+	generate(workspaceElapsedTime: boolean = false) {
 		let largeImageKey: any = 'vscode-big';
 		if (window.activeTextEditor) {
 			if (window.activeTextEditor.document.fileName === this._lastKnownFile) {
 				return this._state = {
 					...this._state,
 					details: this._generateDetails('detailsDebugging', 'detailsEditing', 'detailsIdle', this._state!.largeImageKey),
+					smallImageKey: debug.activeDebugSession ? 'debug' : env.appName.includes('Insiders') ? 'vscode-insiders' : 'vscode',
 					state: this._generateDetails('lowerDetailsDebugging', 'lowerDetailsEditing', 'lowerDetailsIdle', this._state!.largeImageKey),
-					smallImageKey: debug.activeDebugSession ? 'debug' : env.appName.includes('Insiders') ? 'vscode-insiders' : 'vscode'
 				};
 			}
 			this._lastKnownFile = window.activeTextEditor.document.fileName;
 			const filename = basename(window.activeTextEditor.document.fileName);
-			largeImageKey = knownExtentions[Object.keys(knownExtentions).find(key => {
+			largeImageKey = knownExtentions[Object.keys(knownExtentions).find((key) => {
 				if (key.startsWith('.') && filename.endsWith(key)) return true;
 				const match = key.match(/^\/(.*)\/([mgiy]+)$/);
 				if (!match) return false;
 				const regex = new RegExp(match[1], match[2]);
 				return regex.test(filename);
-			})!] || (knownLanguages.includes(window.activeTextEditor.document.languageId) ? window.activeTextEditor.document.languageId : null)
+			})!] || (knownLanguages.includes(window.activeTextEditor.document.languageId) ? window.activeTextEditor.document.languageId : null);
 		}
 
 		let previousTimestamp = null;
@@ -67,8 +70,8 @@ export default class Acivity implements Disposable {
 
 		this._state = {
 			details: this._generateDetails('detailsDebugging', 'detailsEditing', 'detailsIdle', largeImageKey),
-			state: this._generateDetails('lowerDetailsDebugging', 'lowerDetailsEditing', 'lowerDetailsIdle', largeImageKey),
 			startTimestamp: window.activeTextEditor && previousTimestamp && workspaceElapsedTime ? previousTimestamp : window.activeTextEditor ? new Date().getTime() : null,
+			state: this._generateDetails('lowerDetailsDebugging', 'lowerDetailsEditing', 'lowerDetailsIdle', largeImageKey),
 			largeImageKey: largeImageKey ? largeImageKey.image || largeImageKey : 'txt',
 			largeImageText: window.activeTextEditor
 				? this._config.get<string>('largeImage')!
@@ -79,15 +82,19 @@ export default class Acivity implements Disposable {
 				: this._config.get<string>('largeImageIdle'),
 			smallImageKey: debug.activeDebugSession ? 'debug' : env.appName.includes('Insiders') ? 'vscode-insiders' : 'vscode',
 			smallImageText: this._config.get<string>('smallImage')!.replace('{appname}', env.appName),
-			instance: false
+			instance: false,
 		};
 
 		return this._state;
 	}
 
+	dispose() {
+		this._state = null;
+		this._lastKnownFile = '';
+	}
+
 	private _generateDetails(debugging: string, editing: string, idling: string, largeImageKey: any) {
-		const empty = '\u200b\u200b';
-		let raw = this._config.get<string>(idling);
+		let raw: string = this._config.get<string>(idling)!.replace('{null}', empty);
 		let filename = null;
 		let dirname = null;
 		let checkState = false;
@@ -111,11 +118,8 @@ export default class Acivity implements Disposable {
 				fullDirname = `${name}${sep}${relativePath.join(sep)}`;
 			}
 
-			if (debug.activeDebugSession) {
-				raw = this._config.get<string>(debugging);
-			} else {
-				raw = this._config.get<string>(editing);
-			}
+			raw = debug.activeDebugSession ? this._config.get<string>(debugging)! : this._config.get<string>(editing)!;
+
 			const { totalLines, size, currentLine, currentColumn } = this._generateFileDetails(raw);
 			raw = raw!
 				.replace('{null}', empty)
@@ -137,21 +141,20 @@ export default class Acivity implements Disposable {
 	}
 
 	private _generateFileDetails(str?: string) {
-		const fileDetail: FileDetail = {};
+		const fileDetail: IFileDetail = {};
 		if (!str) return fileDetail;
 
 		if (window.activeTextEditor) {
-			if (str.includes('{totallines}')) {
+			if (str.includes('{totallines}'))
 				fileDetail.totalLines = window.activeTextEditor.document.lineCount.toLocaleString();
-			}
-			if (str.includes('{currentline}')) {
+
+			if (str.includes('{currentline}'))
 				fileDetail.currentLine = (window.activeTextEditor.selection.active.line + 1).toLocaleString();
-			}
-			if (str.includes('{currentcolumn}')) {
+
+			if (str.includes('{currentcolumn}'))
 				fileDetail.currentColumn = (window.activeTextEditor.selection.active.character + 1).toLocaleString();
-			}
+
 			if (str.includes('{filesize}')) {
-				const sizes = [' bytes', 'kb', 'mb', 'gb', 'tb'];
 				let currentDivision = 0;
 				let { size } = statSync(window.activeTextEditor.document.fileName);
 				const originalSize = size;
@@ -166,12 +169,7 @@ export default class Acivity implements Disposable {
 				fileDetail.size = `${originalSize > 1000 ? size.toFixed(2) : size}${sizes[currentDivision]}`;
 			}
 		}
-		
-		return fileDetail;
-	}
 
-	public dispose() {
-		this._state = null;
-		this._lastKnownFile = '';
+		return fileDetail;
 	}
 }


### PR DESCRIPTION
Since the rewrite, there were a couple of bugs that made the extension just... not work.

A list of things changed:

- Recreate the RPC Client instance on every login call
	- We cannot re-use the client
- Update the config when you use the enable, disable, or reconnect command, as well as every 15 seconds before setting the activity
	- Otherwise, disable never disables, and activity strings never update.
- Moved the status bar item to have a reference in the client
	- Hide it instead of removing it
- Moved the ready logic inside login, since it needs to be set on every client anyways
- tslint a few things
	- This is with my rule-set which I didn't commit as it's outside the scope of this PR. I can commit it in another PR, if wanted.