### PR TITLE
Add `discord.reconnect` as a command

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
 				"command": "discord.disable",
 				"title": "Disable Discord Presence in the current workspace",
 				"category": "Discord Presence"
+			},
+			{
+				"command": "discord.reconnect",
+				"title": "Reconnect Discord Presence to Discord RPC",
+				"category": "Discord Presence"
 			}
 		],
 		"configuration": [


### PR DESCRIPTION
As mentioned in #117, I believe this is enough to add a reconnect command to the `(Ctrl | Cmd) + Shift + P` menu.