### PR TITLE
Add PureScript to known languages

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -62,6 +62,7 @@
 		"perl",
 		"php",
 		"powershell",
+		"purescript",
 		"python",
 		"r",
 		"reasonml",
@@ -690,6 +691,9 @@
 		},
 		".ps1xml": {
 			"image": "powershell"
+		},
+		".purs": {
+			"image": "purescript"
 		},
 		".p": {
 			"image": "pawn"


### PR DESCRIPTION
I'm not sure how the icon works. Is there another step I need to perform elsewhere?