### PR TITLE
feat: add live embedded elixir templates to existing eex icon

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -225,7 +225,7 @@
     ".editorconfig": { "image": "editorconfig" },
     ".ejs": { "image": "ejs" },
     ".ex": { "image": "elixir" },
-    "/\\.(exs|eex)$/i": { "image": "elixir" },
+    "/\\.(exs|l?eex)$/i": { "image": "elixir" },
     "/^mix\\.(exs?|lock)$/i": { "image": "elixir" },
     ".elm": { "image": "elm" },
     ".env": { "image": "env" },


### PR DESCRIPTION
The new Phoenix live views in elixir are named `.html.leex` instead of `.html.eex` so this should help display those files as well