### PR TITLE
feat: .ss and .scm to known extensions

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -229,6 +229,8 @@
 		".ny": { "image": "lisp" },
 		".podsl": { "image": "lisp" },
 		".sexp": { "image": "lisp" },
+		".ss": {"image": "lisp"},
+		".scm": {"image": "lisp"},
 		".ls": { "image": "livescript" },
 		".log": { "image": "log" },
 		".lua": { "image": "lua" },


### PR DESCRIPTION
Added .ss and .scm to a list of known extensions and marked them as being within lisp.