### PR TITLE
Add idle timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
 						"type":"integer",
 						"default": 0,
 						"description": "Set time (in seconds) to disconect rpc when you're idling. 0 is turning off this feature"
-          },
+					},
 					"discord.removeTimestamp": {
 						"type": "boolean",
 						"default": false,

--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
 						"type": "boolean",
 						"default": false,
 						"description": "Removes the lower details"
+					},
+					"discord.idleTimeout": {
+						"type":"integer",
+						"default": 0,
+						"description": "Set time (in seconds) to disconect rpc when you're idling. 0 is turning off this feature"
 					}
 				}
 			}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,4 +55,5 @@ export const enum CONFIG_KEYS {
 	SwapBigAndSmallImage = 'swapBigAndSmallImage',
 	RemoveDetails = 'removeDetails',
 	RemoveLowerDetails = 'removeLowerDetails',
+	IdleTimeout = 'idleTimeout',
 }


### PR DESCRIPTION
This feature enables to disconect discord rpc when vscode is unfocused state. When user starting using vscode from unfocused state, rpc is reconnecting to discord. Time in settings is in seconds.