### PR TITLE
feat: change .sp extension to SourcePawn

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -303,7 +303,7 @@
 		".inc": { "image": "pawn" },
 		".sma": { "image": "pawn" },
 		".pwn": { "image": "pawn" },
-		".sp": { "image": "pawn" },
+		".sp": { "image": "sourcepawn" },
 		"/\\.p(er)?l$/i": { "image": "perl" },
 		".al": { "image": "perl" },
 		".ph": { "image": "perl" },


### PR DESCRIPTION
The image should be the same as the existing `pawn` if possible. SourcePawn is a fork of the original language but doesn't have its own logo.

Closes #843 