### PR TITLE
fix: presence erroring on update if no remote url

### DIFF
--- a/src/activity.ts
+++ b/src/activity.ts
@@ -75,7 +75,7 @@ export async function activity(previous: ActivityPayload = {}) {
 	}
 
 	if (!removeRemoteRepository && git?.repositories.length) {
-		let repo = git.repositories.find((repo) => repo.ui.selected)?.state.remotes[0].fetchUrl;
+		let repo = git.repositories.find((repo) => repo.ui.selected)?.state.remotes[0]?.fetchUrl;
 
 		if (repo) {
 			if (repo.startsWith('git@')) {


### PR DESCRIPTION
Git repositories with no remotes just caused the set activity function to error out, this fixes that.

![image](https://user-images.githubusercontent.com/30955604/115156424-3f053380-a052-11eb-9ab4-9280d2ed1990.png)

Fixes #1009 