### PR TITLE
Added jupyter to known extensions

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -20,6 +20,7 @@
 		{ "language": "haml", "image": "text" },
 		{ "language": "html", "image": "html" },
 		{ "language": "ini", "image": "manifest" },
+		{ "language": "jupyter", "image":"jupyter" },
 		{ "language": "java", "image": "java" },
 		{ "language": "javascript", "image": "javascript" },
 		{ "language": "javascriptreact", "image": "jsx" },


### PR DESCRIPTION
I added the jupyter notebook to `"KNOWN_LANGUAGES"`  as that could possibly solve the issue of the extension not being able to find it and show in discord.

Let me know if I had missed anything, I'll add it