### PR TITLE
Add .prisma support

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -332,6 +332,7 @@
 		"/\\.prettier((rc)|(\\.(toml|yml|yaml|json|js))?$){2}/i": { "image": "prettier" },
 		"prettier.config.js": { "image": "prettier" },
 		"prisma.yml": { "image": "prisma" },
+		".prisma": { "image": "prisma" },
 		".pde": { "image": "processing" },
 		".jade": { "image": "pug" },
 		".pug": { "image": "pug" },


### PR DESCRIPTION
Prisma [switched](https://www.prisma.io/docs/guides/upgrade-guides/upgrade-from-prisma-1/how-to-upgrade) from `prisma.yml` to `.prisma` for version 2. [Documentation](https://www.prisma.io/docs/concepts/components/prisma-schema)