### PR TITLE
Add cuda-cpp support for detected language

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -9,6 +9,7 @@
 		{ "language": "cpp", "image": "cpp" },
 		{ "language": "csharp", "image": "csharp" },
 		{ "language": "css", "image": "css" },
+		{ "language": "cuda-cpp", "image": "cuda" },
 		{ "language": "diff", "image": "manifest" },
 		{ "language": "dockerfile", "image": "docker" },
 		{ "language": "fsharp", "image": "fsharp" },


### PR DESCRIPTION
"cuda-cpp" is the detected language for all CUDA files. Currently only ".cu" files have appropriate image attached while ".cuh" files do not. 