### PR TITLE
Update languages.json for Astro

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -81,6 +81,7 @@
 		".ashx": { "image": "asp" },
 		".asmx": { "image": "asp" },
 		".aspx": { "image": "asp" },
+		".astro": { "image": "astro" },
 		".axd": { "image": "asp" },
 		"/\\.(l?a|[ls]?o|out|s|a51|asm|axf|elf|prx|puff|z80)$/i": { "image": "assembly" },
 		".agc": { "image": "assembly" },


### PR DESCRIPTION
I updated the languages.json file to include the .astro file extension for the new web development framework Astro.

If this gets merged, Make sure to add the Astro logo in to the assets for Discord | [Logo/Image](https://cdn.discordapp.com/icons/830184174198718474/a_2cf14ff4cc05aefc12e52001df35deef.webp)