### PR TITLE
Added the .astro extansion to the language.json

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -81,6 +81,7 @@
 		".ashx": { "image": "asp" },
 		".asmx": { "image": "asp" },
 		".aspx": { "image": "asp" },
+		".astro": { "image": "astro" },
 		".axd": { "image": "asp" },
 		"/\\.(l?a|[ls]?o|out|s|a51|asm|axf|elf|prx|puff|z80)$/i": { "image": "assembly" },
 		".agc": { "image": "assembly" },


### PR DESCRIPTION
Since the resolveFileIcon function in utils.ts returns just the string "astro", i'm not quite sure if this suffices to display the astro img in discord. Further help? teach me senpai