### PR TITLE
Adding support to Microsoft Q# quantum development kit. The image val…

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -1,5 +1,6 @@
 {
 	"KNOWN_LANGUAGES": [
+		{ "language": "qsharp", "image": "qsharp" },
 		{ "language": "abap", "image": "text" },
 		{ "language": "bat", "image": "bat" },
 		{ "language": "bibtex", "image": "text" },
@@ -64,6 +65,7 @@
 		{ "language": "yaml", "image": "yaml" }
 	],
 	"KNOWN_EXTENSIONS": {
+		".qs": { "image": "qsharp" },
 		".ahk": { "image": "ahk" },
 		".ahkl": { "image": "ahk" },
 		"androidmanifest.xml": { "image": "android" },


### PR DESCRIPTION
I was doing some work today and noticed that the extension don't give support to the Q# language ( Microsoft's quantum computing development kit ), so I tried to add support to it.
As far as I understood, all the support is handled in the languages.json file so I added the keys there ( couldn't find the image referencing location tho, so I set it to "qsharp" [ like it is by default in vscode ]) 
![Screenshot 2023-12-27 195604](https://github.com/iCrawl/discord-vscode/assets/147345333/a33500af-d8d5-420b-ad20-5f8f94bb4cd5)

That's a really simple change, nothing major.

