### PR TITLE
Add {file_extension} and {FILE_EXTENSION} as replaceable strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
 					"discord.largeImage": {
 						"type": "string",
 						"default": "Editing a {LANG} file",
-						"description": "Custom string for the largeImageText section of the rich presence.\n\t- '{lang}' will be replaced with the lowercased language ID\n\t- '{LANG}' will be replaced with the uppercased language ID"
+						"description": "Custom string for the largeImageText section of the rich presence.\n\t- '{lang}' will be replaced with the lowercased language ID\n\t- '{Lang}' will be replaced with the titlecased language ID\n\t- '{LANG}' will be replaced with the uppercased language ID\n\t- '{file_extension}' will be replaced with the lowercased file extension\n\t- '{FILE_EXTENSION}' will be replaced with the uppercased file extension"
 					},
 					"discord.smallImage": {
 						"type": "string",

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -113,6 +113,8 @@ async function details(idling: CONFIG_KEYS, editing: CONFIG_KEYS, debugging: CON
 		const { dir } = parse(window.activeTextEditor.document.fileName);
 		const split = dir.split(sep);
 		const dirName = split[split.length - 1];
+		const fileNameSplit = fileName.includes('.') ? fileName.split('.') : [''];
+		const fileExtension = fileNameSplit[fileNameSplit.length - 1];
 
 		const noWorkspaceFound = config[CONFIG_KEYS.LowerDetailsNoWorkspaceFound].replace(REPLACE_KEYS.Empty, FAKE_EMPTY);
 		const workspaceFolder = workspace.getWorkspaceFolder(window.activeTextEditor.document.uri);
@@ -150,7 +152,9 @@ async function details(idling: CONFIG_KEYS, editing: CONFIG_KEYS, debugging: CON
 			.replace(REPLACE_KEYS.WorkspaceAndFolder, workspaceAndFolder)
 			.replace(REPLACE_KEYS.LanguageLowerCase, toLower(fileIcon))
 			.replace(REPLACE_KEYS.LanguageTitleCase, toTitle(fileIcon))
-			.replace(REPLACE_KEYS.LanguageUpperCase, toUpper(fileIcon));
+			.replace(REPLACE_KEYS.LanguageUpperCase, toUpper(fileIcon))
+			.replace(REPLACE_KEYS.ExtensionLowerCase, toLower(fileExtension))
+			.replace(REPLACE_KEYS.ExtensionUpperCase, toUpper(fileExtension));
 	}
 
 	return raw;
@@ -214,10 +218,15 @@ export async function activity(previous: ActivityPayload = {}) {
 
 	if (window.activeTextEditor) {
 		const largeImageKey = resolveFileIcon(window.activeTextEditor.document);
+		const fileName = basename(window.activeTextEditor.document.fileName);
+		const fileNameSplit = fileName.includes('.') ? fileName.split('.') : [''];
+		const fileExtension = fileNameSplit[fileNameSplit.length - 1];
 		const largeImageText = config[CONFIG_KEYS.LargeImage]
 			.replace(REPLACE_KEYS.LanguageLowerCase, toLower(largeImageKey))
 			.replace(REPLACE_KEYS.LanguageTitleCase, toTitle(largeImageKey))
 			.replace(REPLACE_KEYS.LanguageUpperCase, toUpper(largeImageKey))
+			.replace(REPLACE_KEYS.ExtensionLowerCase, toLower(fileExtension))
+			.replace(REPLACE_KEYS.ExtensionUpperCase, toUpper(fileExtension))
 			.padEnd(2, FAKE_EMPTY);
 
 		state = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,8 @@ export const enum REPLACE_KEYS {
 	LanguageLowerCase = '{lang}',
 	LanguageTitleCase = '{Lang}',
 	LanguageUpperCase = '{LANG}',
+	ExtensionLowerCase = '{file_extension}',
+	ExtensionUpperCase = '{FILE_EXTENSION}',
 	TotalLines = '{total_lines}',
 	CurrentLine = '{current_line}',
 	CurrentColumn = '{current_column}',


### PR DESCRIPTION
I've wanted this as a feature, so I decided to implement it myself.

'{file_extension}' will be replaced with the lowercased file extension. '{FILE_EXTENSION}' will be replaced with the uppercased file extension.

"Editing a .{file_extension} file" will yield "Editing a .ts file", or whatever file extension is being edited.