### PR TITLE
Add the ability for "file_name_no_ext"

### DIFF
--- a/src/activity.ts
+++ b/src/activity.ts
@@ -113,6 +113,7 @@ async function details(idling: CONFIG_KEYS, editing: CONFIG_KEYS, debugging: CON
 		const { dir } = parse(window.activeTextEditor.document.fileName);
 		const split = dir.split(sep);
 		const dirName = split[split.length - 1];
+		const fileNameNoExt = fileName.split('.').slice(0, -1).join('.');
 
 		const noWorkspaceFound = config[CONFIG_KEYS.LowerDetailsNoWorkspaceFound].replace(REPLACE_KEYS.Empty, FAKE_EMPTY);
 		const workspaceFolder = workspace.getWorkspaceFolder(window.activeTextEditor.document.uri);
@@ -144,6 +145,7 @@ async function details(idling: CONFIG_KEYS, editing: CONFIG_KEYS, debugging: CON
 		}
 		raw = raw
 			.replace(REPLACE_KEYS.FileName, fileName)
+			.replace(REPLACE_KEYS.FileNameNoExt, fileNameNoExt)
 			.replace(REPLACE_KEYS.DirName, dirName)
 			.replace(REPLACE_KEYS.Workspace, workspaceName)
 			.replace(REPLACE_KEYS.WorkspaceFolder, workspaceFolderName)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const UNKNOWN_GIT_REPO_NAME = 'Unknown' as const;
 export const enum REPLACE_KEYS {
 	Empty = '{empty}',
 	FileName = '{file_name}',
+	FileNameNoExt = '{file_name_no_ext}',
 	DirName = '{dir_name}',
 	FullDirName = '{full_dir_name}',
 	Workspace = '{workspace}',


### PR DESCRIPTION
I needed the ability to do `{dir_name}.{file_name_no_ext}`, and I saw that you didn't support it, so I decided to implement it.

I decided to do `fileName.split('.').slice(0, -1).join('.')`, because I also needed the ability to see the first ending. 

Example:
`FileName.lua` -> `Filename`.
`FileName.server.lua` -> `Filename.server`.

![image](https://github.com/iCrawl/discord-vscode/assets/94411511/fc7ceadf-f96c-4416-8a20-18a68237e963)
