### PR TITLE
feat: Add support for Ada lang

### DIFF
--- a/src/data/languages.json
+++ b/src/data/languages.json
@@ -1,6 +1,7 @@
 {
 	"KNOWN_LANGUAGES": [
 		{ "language": "abap", "image": "text" },
+		{ "language": "ada", "image": "ada" },
 		{ "language": "bat", "image": "bat" },
 		{ "language": "bibtex", "image": "text" },
 		{ "language": "clojure", "image": "clojure" },
@@ -75,6 +76,8 @@
 		".as": { "image": "as" },
 		".jsfl": { "image": "as" },
 		".swc": { "image": "as" },
+		".adb": { "image": "ada" },
+		".ads": { "image": "ada" },
 		".asp": { "image": "asp" },
 		".asax": { "image": "asp" },
 		".ascx": { "image": "asp" },


### PR DESCRIPTION
Hey!  
This PR adds support for the programming language Ada by adding `.ads` & `.adb` to the list of known extensions.

Here is the icon used by Ada:  
![adalang-icon](https://github.com/iCrawl/discord-vscode/assets/35304405/29ee9a96-6bc3-4e4d-9cb8-0202aba45b82)
