### PR TITLE
feat: add a manual disconnect option for the status bar icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
 					"discord.disconnectButton": {
 						"type": "boolean",
 						"default": false,
-						"description": "Enables manually disconnecting by clicking the status bar icon"
+						"description": "Enables the option to manually disconnect by clicking the status bar icon"
 					},
 					"discord.removeDetails": {
 						"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -188,6 +188,11 @@
 						"default": false,
 						"description": "Swaps the big and small image on the rich presence"
 					},
+					"discord.disconnectButton": {
+						"type": "boolean",
+						"default": false,
+						"description": "Enables manually disconnecting by clicking the status bar icon"
+					},
 					"discord.removeDetails": {
 						"type": "boolean",
 						"default": false,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,6 +43,7 @@ export const enum CONFIG_KEYS {
 	DetailsDebugging = 'detailsDebugging',
 	DetailsEditing = 'detailsEditing',
 	DetailsIdling = 'detailsIdling',
+	DisconnectButton = 'disconnectButton',
 	Enabled = 'enabled',
 	IdleTimeout = 'idleTimeout',
 	LargeImage = 'largeImage',


### PR DESCRIPTION
Adds the option to manually disconnect via the status bar icon when the setting is enabled (disabled by default).

Useful for when needing to temporarily disable the rich presence from the extension.