### PR TITLE
fix: only remove .git if it's a subfolder

### DIFF
--- a/src/activity.ts
+++ b/src/activity.ts
@@ -97,7 +97,7 @@ async function fileDetails(_raw: string, document: TextDocument, selection: Sele
 				git.repositories
 					?.find((repo) => repo.ui.selected)
 					?.state.remotes[0]?.fetchUrl?.split('/')[1]
-					?.replace('.git', '') ?? FAKE_EMPTY,
+					?.replace('/.git', '/') ?? FAKE_EMPTY,
 			);
 		} else {
 			raw = raw.replace(REPLACE_KEYS.GitRepoName, UNKNOWN_GIT_REPO_NAME);


### PR DESCRIPTION
Previous behaviour:
- `/RepoName/.git` -> `/RepoName/`
- `/RepoName.git` -> `/RepoName`

The first case is fine because there's a very strong implied guarantee that a `/RepoName/` folder exists due to access into the .git subfolder.

However, in the second case there is only hopes and prayers because for example an HTTP server could provide only a bare repo (or even more advanced use cases) in which case omission of the `.git` is just asking for a 404.