### PR TITLE
Added support for data base viewers. No idle fallback when using data base viewers in VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ bun.lockb
 .prettiercache
 .eslintcache
 .vercel
+
+#npm
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -135,6 +135,11 @@
 						"default": "Debugging {file_name}",
 						"description": "Custom string for the details section of the rich presence when debugging\n\t- '{empty}' will be replaced with an empty space.\n\t- '{file_name}' will be replaced with the current file name.\n\t- '{dir_name}' will get replaced with the folder name that has the current file.\n\t- '{full_dir_name}' will get replaced with the full directory name without the current file name.\n\t- '{workspace}' will be replaced with the current workspace name, if any.\n\t- '{workspace_folder}' will be replaced with the currently accessed workspace folder, if any.\n\t- '{workspace_and_folder} will be replaced with the currently accessed workspace and workspace folder like this: 'Workspace - WorkspaceFolder'\n\t- '{current_column}' will get replaced with the current column of the current line.\n\t- '{current_line}' will get replaced with the current line number.\n\t- '{total_lines}' will get replaced with the total line number.\n\t- '{file_size}' will get replaced with the current file's size.\n\t- '{git_repo_name}' will be replaced with the active Git repository name (from the git URL)\n\t- '{git_branch}' will be replaced with the current active branch name."
 					},
+					"discord.detailsViewingDatabase": {
+						"type": "string",
+						"default": "Viewing {file_name}",
+						"description": "Custom string for the details section of the rich presence when Viewing suporrted database extensions\n\t - '{empty} will be replaced with an empty space. \n\t - {file_name}' will be replaced with the name of currentylu wieving database.\n\t- '{full_dir_name}' will get replaced with the full directory name without the current file name.\n\t- '{workspace}' will be replaced with the current workspace name, if any.\n\t- '{workspace_folder}' will be replaced with the currently accessed workspace folder, if any.\n\t- '{workspace_and_folder} will be replaced with the currently accessed workspace and workspace folder like this: 'Workspace - WorkspaceFolder'"
+					},
 					"discord.lowerDetailsIdling": {
 						"type": "string",
 						"default": "Idling",
@@ -150,6 +155,11 @@
 						"default": "Debugging: {workspace}",
 						"description": "Custom string for the state section of the rich presence when debugging\n\t- '{empty}' will be replaced with an empty space.\n\t- '{file_name}' will be replaced with the current file name.\n\t- '{dir_name}' will get replaced with the folder name that has the current file.\n\t- '{full_dir_name}' will get replaced with the full directory name without the current file name.\n\t- '{workspace}' will be replaced with the current workspace name, if any.\n\t- '{workspace_folder}' will be replaced with the currently accessed workspace folder, if any.\n\t- '{workspace_and_folder} will be replaced with the currently accessed workspace and workspace folder like this: 'Workspace - WorkspaceFolder'\n\t- '{current_column}' will get replaced with the current column of the current line.\n\t- '{current_line}' will get replaced with the current line number.\n\t- '{total_lines}' will get replaced with the total line number.\n\t- '{file_size}' will get replaced with the current file's size.\n\t- '{git_repo_name}' will be replaced with the active Git repository name (from the git URL)\n\t- '{git_branch}' will be replaced with the current active branch name."
 					},
+					"discord.lowerDetailsViewingDatabase": {
+						"type": "string",
+						"default": "Workspace: {workspace}",
+						"description": "Custom string for the state section of the rich presence\n\t- '{empty}' will be replaced with an empty space.\n\t- '{file_name}' will be replaced with the current file name.\n\t- '{dir_name}' will get replaced with the folder name that has the current file.\n\t- '{full_dir_name}' will get replaced with the full directory name without the current file name.\n\t- '{workspace}' will be replaced with the current workspace name, if any.\n\t- '{workspace_folder}' will be replaced with the currently accessed workspace folder, if any.\n\t- '{workspace_and_folder} will be replaced with the currently accessed workspace and workspace folder like this: 'Workspace - WorkspaceFolder'\n\t"
+					},
 					"discord.lowerDetailsNoWorkspaceFound": {
 						"type": "string",
 						"default": "No workspace",
@@ -159,6 +169,11 @@
 						"type": "string",
 						"default": "Idling",
 						"description": "Custom string for the largeImageText section of the rich presence when idling"
+					},
+					"discord.largeImageViewiengDatabase": {
+						"type": "string",
+						"default": "Viewing a databse  file",
+						"description": "Custom string for the largeImageText section of the rich presence. when displaying data base files"
 					},
 					"discord.largeImage": {
 						"type": "string",

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
 					},
 					"discord.largeImageViewiengDatabase": {
 						"type": "string",
-						"default": "Viewing a databse  file",
+						"default": "Viewing a database  file",
 						"description": "Custom string for the largeImageText section of the rich presence. when displaying data base files"
 					},
 					"discord.largeImage": {

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -164,8 +164,6 @@ async function details(idling: CONFIG_KEYS, editing: CONFIG_KEYS, debugging: CON
 			.replace(REPLACE_KEYS.LanguageLowerCase, toLower(fileIcon))
 			.replace(REPLACE_KEYS.LanguageTitleCase, toTitle(fileIcon))
 			.replace(REPLACE_KEYS.LanguageUpperCase, toUpper(fileIcon));
-
-		log(LogLevel.Info, `raw: ${raw}`);
 	} else if (tabInput) {
 		const activeTab = window.tabGroups.activeTabGroup.activeTab;
 		if (activeTab?.input instanceof TabInputCustom) {
@@ -189,11 +187,6 @@ async function details(idling: CONFIG_KEYS, editing: CONFIG_KEYS, debugging: CON
 				relativePath.splice(-1, 1);
 				raw = raw.replace(REPLACE_KEYS.FullDirName, `${name}${sep}${relativePath.join(sep)}`);
 			}
-
-			log(
-				LogLevel.Debug,
-				`workspaceFolder: ${workspaceFolder?.name}, uri: ${uri.fsPath}, workspaceName: ${workspaceName}`,
-			);
 
 			raw = raw
 				.replace(REPLACE_KEYS.FileName, fileName)

--- a/src/activity.ts
+++ b/src/activity.ts
@@ -277,18 +277,14 @@ export async function activity(previous: ActivityPayload = {}) {
 	const activeTab = window.tabGroups.activeTabGroup.activeTab;
 	const tabInput = activeTab?.input instanceof TabInputCustom ? activeTab.input : null;
 	if (tabInput) {
-		log(LogLevel.Info, `else block entered`);
 		const activeTab = window.tabGroups.activeTabGroup.activeTab;
-		log(LogLevel.Info, `activeTab: ${activeTab?.label}`);
 		const tabInput = activeTab?.input instanceof TabInputCustom ? activeTab.input : null;
-		log(LogLevel.Info, `tabInput: ${tabInput?.uri.fsPath}`);
 		if (tabInput) {
 			const ext = parse(tabInput.uri.fsPath).ext.slice(1).toLowerCase();
 			const DB_EXTENSIONS = ['db', 'sqlite', 'sqlite3'];
 			if (DB_EXTENSIONS.includes(ext)) {
 				// Viewing datbase file, other activites can be added in else if statments.
 				const largeImageKey = 'sql';
-				log(LogLevel.Info, `LargeImageViewingDatabase config: ${config[CONFIG_KEYS.LargeImageViewingDatabase]}`);
 				const largeImageText = config[CONFIG_KEYS.LargeImageViewingDatabase]
 					.replace(REPLACE_KEYS.LanguageLowerCase, toLower(largeImageKey))
 					.replace(REPLACE_KEYS.LanguageTitleCase, toTitle(largeImageKey))

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,7 @@ export const UNKNOWN_GIT_REPO_NAME = 'Unknown' as const;
 export const enum REPLACE_KEYS {
 	AppName = '{app_name}',
 	CurrentColumn = '{current_column}',
+	CurrentErrors = '{current_errors}',
 	CurrentLine = '{current_line}',
 	DirName = '{dir_name}',
 	Empty = '{empty}',
@@ -37,21 +38,23 @@ export const enum REPLACE_KEYS {
 	Workspace = '{workspace}',
 	WorkspaceAndFolder = '{workspace_and_folder}',
 	WorkspaceFolder = '{workspace_folder}',
-	CurrentErrors = '{current_errors}',
 }
 
 export const enum CONFIG_KEYS {
 	DetailsDebugging = 'detailsDebugging',
 	DetailsEditing = 'detailsEditing',
 	DetailsIdling = 'detailsIdling',
+	DetailsViewingDatabase = 'detailsViewingDatabase',
 	Enabled = 'enabled',
 	IdleTimeout = 'idleTimeout',
 	LargeImage = 'largeImage',
 	LargeImageIdling = 'largeImageIdling',
+	LargeImageViewingDatabase = 'largeImageViewiengDatabase',
 	LowerDetailsDebugging = 'lowerDetailsDebugging',
 	LowerDetailsEditing = 'lowerDetailsEditing',
 	LowerDetailsIdling = 'lowerDetailsIdling',
 	LowerDetailsNoWorkspaceFound = 'lowerDetailsNoWorkspaceFound',
+	LowerDetailsViewingDatabase = 'lowerDetailsViewingDatabase',
 	RemoveDetails = 'removeDetails',
 	RemoveLowerDetails = 'removeLowerDetails',
 	RemoveRemoteRepository = 'removeRemoteRepository',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,8 +46,15 @@ async function login() {
 		const onChangeTextDocument = workspace.onDidChangeTextDocument(throttle(async () => sendActivity(), 2_000));
 		const onStartDebugSession = debug.onDidStartDebugSession(async () => sendActivity());
 		const onTerminateDebugSession = debug.onDidTerminateDebugSession(async () => sendActivity());
+		const onChangeActiveTab = window.tabGroups.onDidChangeTabGroups(async () => sendActivity());
 
-		listeners.push(onChangeActiveTextEditor, onChangeTextDocument, onStartDebugSession, onTerminateDebugSession);
+		listeners.push(
+			onChangeActiveTextEditor,
+			onChangeTextDocument,
+			onStartDebugSession,
+			onTerminateDebugSession,
+			onChangeActiveTab,
+		);
 	});
 
 	rpc.on('disconnected', () => {


### PR DESCRIPTION
### What
Adds support for database file viewers so Rich Presence can display database files (e.g. `.db`) instead of only files opened in the text editor.

### Why
Previously the extension relied only on the `window.activeTextEditor` API.  
Database files opened through database viewer extensions are not handled by the text editor API, which caused the extension to fall back to the "Idling" presence state.


### How
- Replaced hardcoded `window.activeTextEditor` checks with logic based on `window.tabGroups.activeTabGroup.activeTab`
- Added detection for database viewer tabs
- Added database icon support using existing assets
- Added workspace name display when viewing database files
- Preserved existing Rich Presence behavior for text editor files

### Testing
1. Open any database file (e.g. SQLite `.db`) using a database viewer extension (tested with SQLite Viewer)
2. Verify that Discord Rich Presence displays:
   - Viewing: `<filename>.<ext>`
   - Workspace: `<workspace name>`
   - Database icon with hover text: "Viewing database file"
3. Confirm that time elapsed and other Rich Presence elements remain unchanged

### Example photo
<img width="282" height="132" alt="Zrzut ekranu 2026-02-11 151908" src="https://github.com/user-attachments/assets/b1203fc4-bcbd-4369-b253-e8082dc3aef2" />
